### PR TITLE
Dev fix ws timeout and concurrent map

### DIFF
--- a/danmu-core/core/client.go
+++ b/danmu-core/core/client.go
@@ -360,7 +360,7 @@ func (c *Client) write(data []byte) error {
 	if conn == nil {
 		return fmt.Errorf("connection not available")
 	}
-	conn.SetWriteDeadline(time.Now().Add(time.Second * 5))
+	conn.SetWriteDeadline(time.Now().Add(time.Second * 8))
 	return conn.WriteMessage(websocket.BinaryMessage, data)
 }
 
@@ -371,7 +371,7 @@ func (c *Client) read() (int, []byte, error) {
 	if conn == nil {
 		return 0, nil, fmt.Errorf("connection not available")
 	}
-	conn.SetReadDeadline(time.Now().Add(time.Second * 5))
+	conn.SetReadDeadline(time.Now().Add(time.Second * 120))
 	return conn.ReadMessage()
 }
 

--- a/danmu-core/core/client.go
+++ b/danmu-core/core/client.go
@@ -324,7 +324,14 @@ func (c *Client) processMsg() {
 	for {
 		select {
 		case <-c.ctx.Done():
-			return
+			for response, ok := <-c.RecvMsg; ; {
+				if !ok {
+					logger.Info().Str("liveurl", c.liveurl).Msg("Channel closed, Stop ProcessingRecvMessage()")
+					c.RecvMsg = nil
+					return
+				}
+				c.emit(response)
+			}
 
 		case response, ok := <-c.RecvMsg:
 			if !ok {


### PR DESCRIPTION
+ 修改websocket read write超时时间，防止重连过于频繁导致服务端异常
+ 修改task_manager.go初始化逻辑，改为并发创建任务，并新建rwmutex控制map并发读写
+ 修改client.go processMessage和fetchMesage的channel逻辑，解决在触发cancelfunc时直接退出协程，导致chan RecvMsg缓存中的数据没有完全被processMessage协程完全消费