### PR TITLE
Dev fix ws timeout and concurrent map (#13)

### DIFF
--- a/danmu-core/core/client.go
+++ b/danmu-core/core/client.go
@@ -161,11 +161,6 @@ func (c *Client) close() {
 	}
 	c.connMu.Unlock()
 
-	if c.RecvMsg != nil {
-		close(c.RecvMsg)
-		c.RecvMsg = nil
-	}
-
 	logger.Info().Str("liveurl", c.liveurl).Msg("客户端已关闭")
 }
 
@@ -282,6 +277,7 @@ func (c *Client) heartbeat() {
 }
 
 func (c *Client) fetchMessage() {
+	defer close(c.RecvMsg)
 	for {
 		select {
 		case <-c.ctx.Done():
@@ -321,20 +317,12 @@ func (c *Client) fetchMessage() {
 }
 
 func (c *Client) processMsg() {
-	for {
-		select {
-		case <-c.ctx.Done():
-			return
 
-		case response, ok := <-c.RecvMsg:
-			if !ok {
-				logger.Info().Str("liveurl", c.liveurl).Msg("Channel closed, Stop ProcessingRecvMessage()")
-				c.RecvMsg = nil
-				return
-			}
-			c.emit(response)
-		}
+	for msg := range c.RecvMsg {
+		c.emit(msg)
 	}
+	logger.Info().Str("liveurl", c.liveurl).Msg("Channel closed, Stop ProcessingRecvMessage()")
+	c.RecvMsg = nil
 }
 
 func (c *Client) checkStreamTask() {
@@ -360,7 +348,7 @@ func (c *Client) write(data []byte) error {
 	if conn == nil {
 		return fmt.Errorf("connection not available")
 	}
-	conn.SetWriteDeadline(time.Now().Add(time.Second * 5))
+	conn.SetWriteDeadline(time.Now().Add(time.Second * 8))
 	return conn.WriteMessage(websocket.BinaryMessage, data)
 }
 
@@ -371,7 +359,7 @@ func (c *Client) read() (int, []byte, error) {
 	if conn == nil {
 		return 0, nil, fmt.Errorf("connection not available")
 	}
-	conn.SetReadDeadline(time.Now().Add(time.Second * 5))
+	conn.SetReadDeadline(time.Now().Add(time.Second * 120))
 	return conn.ReadMessage()
 }
 


### PR DESCRIPTION
* fix: handle websocket timeout and concurrent map race

- 调整WebSocket客户端超时时间，避免因连接长时间空闲被服务端断开，导致服务端异常
- 将`task_manager.go`中的相关map使用rw mutex控制，实现并发安全的锁管理
- 确保Add()等函数在高并发下不会重复启动任务或写入异常"

* fix: RecvMsg channel may cause memory leaked

- processMsg() 会在其他协程触发 cancelFunc的时候直接退出，导致RecvMsg中buffer剩余的数据可能没有消费完成，修改了context cancelFunc 触发时的分支直接返回的逻辑，修改为会继续消费channel中的数据直到数据消费完成

* fix: RecvMsg channel may cause memory leaked

- processMsg() 会在其他协程触发 cancelFunc的时候直接退出，导致RecvMsg中buffer剩余的数据可能没有消费完成，修改了context cancelFunc 触发时的分支直接返回的逻辑，修改为会继续消费channel中的数据直到数据消费完成